### PR TITLE
fix: raise payment modal z-index above page; add SEO metadata to org …

### DIFF
--- a/cms/src/app/(pay)/organizations/[id]/page.tsx
+++ b/cms/src/app/(pay)/organizations/[id]/page.tsx
@@ -63,10 +63,53 @@ async function getBusiness(id: string): Promise<BusinessDetail | null> {
 export async function generateMetadata({ params }: any): Promise<Metadata> {
   const { id } = await params
   const b = await getBusiness(id)
-  if (!b) return { title: 'Organization not found · Hoga' }
+
+  if (!b) {
+    return {
+      title: 'Organization not found · Hoga',
+      description: 'This organization could not be found on Hoga.',
+      robots: { index: false, follow: false },
+    }
+  }
+
+  const title = `Support ${b.businessName} on Hoga`
+  const description =
+    `Browse and contribute to ${b.businessName}'s ` +
+    `${b.campaignCount} ${b.campaignCount === 1 ? 'campaign' : 'campaigns'} on Hoga` +
+    (b.country ? ` · ${b.country}.` : '.')
+
+  // Prefer the organizer photo, else the first campaign image.
+  const ogImage = b.photoUrl || b.campaigns.find((c) => c.imageUrl)?.imageUrl || null
+  const canonical = `/organizations/${id}`
+
   return {
-    title: `${b.businessName} · Campaigns on Hoga`,
-    description: `Support ${b.businessName}'s campaigns. ${b.campaignCount} active on Hoga.`,
+    title,
+    description,
+    keywords: [
+      'fundraising',
+      'donation',
+      'contribution',
+      'Hoga',
+      b.businessName,
+      b.username || '',
+      b.country || '',
+    ].filter(Boolean),
+    alternates: { canonical },
+    robots: { index: true, follow: true },
+    openGraph: {
+      title,
+      description,
+      type: 'profile',
+      url: canonical,
+      siteName: 'Hoga',
+      images: ogImage ? [{ url: ogImage, alt: b.businessName }] : [],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: ogImage ? [ogImage] : [],
+    },
   }
 }
 

--- a/cms/src/components/PaymentWaitingModal.tsx
+++ b/cms/src/components/PaymentWaitingModal.tsx
@@ -31,7 +31,7 @@ export default function PaymentWaitingModal({
   if (!isOpen) return null
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center">
       {/* Backdrop */}
       <div className="absolute inset-0 bg-black/50" onClick={onClose} />
 

--- a/cms/src/components/ThreeDSModal.tsx
+++ b/cms/src/components/ThreeDSModal.tsx
@@ -16,7 +16,7 @@ export default function ThreeDSModal({ isOpen, html, onClose }: ThreeDSModalProp
   if (!isOpen || !html) return null
 
   return (
-    <div className="fixed inset-0 z-50 flex flex-col bg-black/60">
+    <div className="fixed inset-0 z-[9999] flex flex-col bg-black/60">
       <div className="flex items-center justify-between px-4 py-3 bg-white shadow-sm">
         <span className="font-supreme font-medium text-black">Secure card verification</span>
         <button


### PR DESCRIPTION
…page

- ThreeDSModal + PaymentWaitingModal use z-[9999] so page elements no longer stack above the 3D Secure iframe.
- /organizations/[id] emits full OG/Twitter/canonical/robots metadata (organizer photo or first campaign image) instead of falling back to Payload's site defaults.